### PR TITLE
[profile] fix: 뉴스 프로필→멤버 이동 + 연도 영역/탭 UI 보정 + 하이드레이션 에러 수정

### DIFF
--- a/src/api/news.api.ts
+++ b/src/api/news.api.ts
@@ -63,16 +63,18 @@ export const getNewsMember = async (_documentId: string) => {
       const results = await Promise.all(
         data.memberId.map(async memberId => {
           const memberSnapshot = await memberId.get();
-          const { imagePath, name, position } = await getData<{
+          const { imagePath, name, position, order } = await getData<{
             imagePath: string;
             name: string;
             position: string;
+            order: string;
           }>(memberSnapshot);
           const profileImage = await getFileFromStorage(imagePath);
           return {
             profileImage,
             name,
             position,
+            order,
           };
         }),
       );

--- a/src/components/member/IntroduceItem/IntroduceItem.style.ts
+++ b/src/components/member/IntroduceItem/IntroduceItem.style.ts
@@ -50,7 +50,12 @@ const IntroduceItemWrapper = styled.div`
 
       .time {
         color: ${props => props.theme.color.textBlackMedium};
-        min-width: 120px;
+        min-width: 160px;
+        padding-right: 16px;
+        box-sizing: border-box;
+        flex-shrink: 0;
+
+        ${mediaQuery('mobile', `min-width: auto; padding-right: 0;`)};
       }
     }
   }

--- a/src/components/news/Main/Main.style.ts
+++ b/src/components/news/Main/Main.style.ts
@@ -11,6 +11,7 @@ import styled from 'styled-components';
 export const TabSearchBox = styled.div`
   ${flex('space-between', 'center')}
   ${size('64px', 'auto')}
+  gap: 40px;
   margin: 50px 0px 60px;
 
   ${mediaQuery('tablet1024', `${size('64px', 'auto')} margin: 40px 0px;`)};
@@ -19,6 +20,7 @@ export const TabSearchBox = styled.div`
     `
       ${flexDirection('column')}
       ${flex('', 'flex-start')}
+      gap: 0;
       height: 100%;
       margin: 24px 0px 40px 0px;
     `,
@@ -39,7 +41,6 @@ export const TabBox = styled.ul`
     ${mediaQuery('mobile', `min-width: auto; }`)}
   }
   li:nth-child(3) {
-    min-width: 165px;
     ${mediaQuery('mobile', `min-width: auto; }`)}
   }
 `;
@@ -47,21 +48,24 @@ export const TabBox = styled.ul`
 export const Tab = styled.li<{ isActive?: boolean }>`
   ${flex()}
 
-  padding: 6px 20px;
   letter-spacing: -0.4px;
 
   font-weight: ${FontWeight.bold};
   ${font('title22', 'bold')}
 
-  background: ${({ isActive, theme }) =>
-    isActive ? `${theme.color.grey100}; border-radius: 50px` : ''};
-
   a {
+    padding: 6px 20px;
+    border-radius: 50px;
+    background: ${({ isActive, theme }) =>
+      isActive ? theme.color.grey100 : 'transparent'};
+
     color: ${({ isActive, theme }) =>
       isActive ? theme.color.black : 'rgba(6, 11, 17, 0.3)'};
     text-decoration: none;
 
     @media (max-width: ${ScreenBreakPoints['mobile']}) {
+      padding: 6px 0px;
+      background: ${color.white};
       color: ${({ isActive, theme }) =>
         isActive ? theme.color.blue200 : 'rgba(6, 11, 17, 0.3)'};
     }
@@ -71,7 +75,6 @@ export const Tab = styled.li<{ isActive?: boolean }>`
     'mobile',
     `
       ${flex('flex-start')}
-      padding: 6px 0px;
       min-width: 26px;
       margin-right: 16px;
 

--- a/src/components/news/NewsDetail/NewsDetail.interface.ts
+++ b/src/components/news/NewsDetail/NewsDetail.interface.ts
@@ -6,4 +6,5 @@ export interface NewsProfile {
   profileImage: string;
   name: string;
   position: string;
+  order: string;
 }

--- a/src/components/news/NewsDetail/NewsDetail.style.ts
+++ b/src/components/news/NewsDetail/NewsDetail.style.ts
@@ -133,10 +133,11 @@ export const ProfileAreaWrapper = styled.div`
   ${flex()}
 `;
 
-export const ProfileArea = styled.div<{ last: boolean }>`
+export const ProfileArea = styled.div<{ last: boolean; clickable?: boolean }>`
   ${flex()}
   ${flexDirection()}
   ${size('200px', '132px')}
+  cursor: ${({ clickable }) => (clickable ? 'pointer' : 'default')};
   margin-right: ${({ last }) => (last ? '0px' : '50px')};
   @media (max-width: ${ScreenBreakPoints['mobile']}) {
     margin-right: ${({ last }) => (last ? '0px' : '15px')};

--- a/src/components/news/NewsDetail/NewsDetail.tsx
+++ b/src/components/news/NewsDetail/NewsDetail.tsx
@@ -46,6 +46,10 @@ const NewsDetail = (props: Props) => {
     const _id = event.currentTarget.dataset.id as 'prev' | 'next';
     router.push(`/${props.intl.locale}/news/${_id}`);
   };
+  const handleClickProfile = (order: string) => {
+    if (!order) return;
+    router.push(`/${props.intl.locale}/member/${order}`);
+  };
 
   const isMediaNews = newsType === 'media';
   const topTxt = isMediaNews ? agency : '최근 업무사례';
@@ -115,6 +119,8 @@ const NewsDetail = (props: Props) => {
                   <S.ProfileArea
                     key={index}
                     last={index === profile.length - 1}
+                    onClick={() => handleClickProfile(item.order)}
+                    clickable={!!item.order}
                   >
                     <img
                       alt={item.name}

--- a/src/components/news/NewsWrapper/NewsWrapper.style.ts
+++ b/src/components/news/NewsWrapper/NewsWrapper.style.ts
@@ -17,10 +17,9 @@ export const Outer = styled.section<OuterPadding>`
 `;
 
 export const Inner = styled.div<InnerWidth>`
-  width: ${props => props.innerWidth};
+  width: 100%;
+  max-width: ${props => props.innerWidth};
   margin: 0 auto;
-
-  ${mediaQuery('pc1278', `width: 100%;`)}
 `;
 
 export const Title = styled.h1`

--- a/src/pages/[locale]/index.tsx
+++ b/src/pages/[locale]/index.tsx
@@ -4,12 +4,19 @@ import SEO from '@Components/common/Seo/Seo';
 import FifthSection from '@Components/main/FifthSection';
 import SecondSection from '@Components/main/SecondSection';
 import useResize from '@Hooks/useResize';
+import dynamic from 'next/dynamic';
 import * as React from 'react';
 import { localePaths, localeProps } from '@I18n/getStaticProps';
 
-const FirstSection = React.lazy(() => import('@Components/main/FirstSection'));
-const ThirdSection = React.lazy(() => import('@Components/main/ThirdSection'));
-const ForthSection = React.lazy(() => import('@Components/main/ForthSection'));
+const FirstSection = dynamic(() => import('@Components/main/FirstSection'), {
+  loading: () => <Loading height="500px" />,
+});
+const ThirdSection = dynamic(() => import('@Components/main/ThirdSection'), {
+  loading: () => <Loading height="500px" />,
+});
+const ForthSection = dynamic(() => import('@Components/main/ForthSection'), {
+  loading: () => <Loading height="500px" />,
+});
 
 const Main = () => {
   const { isMobile, isTablet, isDesktop } = useResize();
@@ -21,20 +28,14 @@ const Main = () => {
     <>
       <SEO />
       <Layout route="main" isMobile={isMobile} isTransparent={isTransparent}>
-        <React.Suspense fallback={<Loading height="500px" />}>
-          <FirstSection
-            isMobile={isMobile}
-            isDesktop={isDesktop}
-            eventBus={eventBus}
-          />
-        </React.Suspense>
+        <FirstSection
+          isMobile={isMobile}
+          isDesktop={isDesktop}
+          eventBus={eventBus}
+        />
         <SecondSection isMobile={isMobile} />
-        <React.Suspense fallback={<Loading height="500px" />}>
-          <ThirdSection isMobile={isMobile} isTablet={isTablet} />
-        </React.Suspense>
-        <React.Suspense fallback={<Loading height="500px" />}>
-          <ForthSection isMobile={isMobile} isTablet={isTablet} />
-        </React.Suspense>
+        <ThirdSection isMobile={isMobile} isTablet={isTablet} />
+        <ForthSection isMobile={isMobile} isTablet={isTablet} />
         <FifthSection isMobile={isMobile} />
       </Layout>
     </>

--- a/src/pages/[locale]/news/[id].tsx
+++ b/src/pages/[locale]/news/[id].tsx
@@ -1,13 +1,11 @@
 import Layout from '@Components/common/Layout/Layout';
-import Loading from '@Components/common/Loading';
 import SEO from '@Components/common/Seo/Seo';
+import NewsDetail from '@Components/news/NewsDetail/NewsDetail';
 import NewsWrapper from '@Components/news/NewsWrapper';
 import { News } from '@Interface/api.interface';
 import { locales } from '@I18n/config';
 import { GetStaticPaths, GetStaticProps } from 'next';
-import React, { lazy, Suspense } from 'react';
-
-const NewsDetail = lazy(() => import('@Components/news/NewsDetail/NewsDetail'));
+import React from 'react';
 
 interface Props {
   news: News;
@@ -31,9 +29,7 @@ const NewsDetailPage: React.FC<Props> = ({ news }) => {
         ogImage={news?.newsImageData?.src || undefined}
       />
       <NewsWrapper outerPadding="100px 90px 160px" innerWidth="996px">
-        <Suspense fallback={<Loading height="500px" />}>
-          <NewsDetail {...news} />
-        </Suspense>
+        <NewsDetail {...news} />
       </NewsWrapper>
     </Layout>
   );


### PR DESCRIPTION
## Summary

뉴스 상세의 프로필 클릭 시 해당 멤버 페이지로 이동하도록 연결하고, 멤버 소개 연도 표시 영역과 뉴스 탭 UI 여백을 보정했습니다. 아울러 Pages Router에서 `React.lazy`로 인한 하이드레이션 경고를 `next/dynamic`/직접 import 전환으로 해결했습니다.

## Changes

- **fix(news/member)**: 뉴스 상세 프로필 클릭 시 `/:locale/member/:order`로 이동 (`getNewsMember`가 `order` 반환 → `NewsProfile`/`NewsDetail` 연결, `clickable` 커서 표시)
- **fix(news/member)**: `IntroduceItem` 연도 표시 영역 너비 확대(120→160px) 및 값과의 간격 확보 (모바일은 기존 컬럼 레이아웃 유지)
- **fix(hydration)**: `news/[id].tsx`는 `NewsDetail` 직접 import, `index.tsx`는 `next/dynamic`으로 전환해 Suspense 하이드레이션 경고 제거
- **fix(news)**: 탭 활성 배경·탭/검색 여백, 뷰포트 1279~1380px Inner 오버플로 보정

## Test plan

- [ ] `pnpm lint && pnpm tsc && pnpm build` 통과
- [ ] 뉴스 상세에서 프로필 클릭 → 해당 멤버 페이지(`/ko/member/L020/` 등) 이동 확인
- [ ] `order` 없는 멤버는 클릭 무효 + 커서 기본값 확인
- [ ] 멤버 상세 경력/학력/논문 연도 영역이 값과 겹치지 않는지 확인 (영문 "2025-Present" 포함)
- [ ] 메인/뉴스 상세 진입 시 하이드레이션 경고 미발생 확인
- [ ] 1279~1380px 구간 뉴스 Inner 오버플로 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)