### PR TITLE
fix(news): 이미지 찌그러짐·탭 줄바꿈·프로필 버튼 깜빡임 수정

### DIFF
--- a/src/components/news/Main/Main.style.ts
+++ b/src/components/news/Main/Main.style.ts
@@ -48,6 +48,7 @@ export const Tab = styled.li<{ isActive?: boolean }>`
   ${flex()}
 
   padding: 6px 20px;
+  white-space: nowrap;
   letter-spacing: -0.4px;
 
   font-weight: ${FontWeight.bold};

--- a/src/components/news/NewsDetail/NewsDetail.style.ts
+++ b/src/components/news/NewsDetail/NewsDetail.style.ts
@@ -114,6 +114,11 @@ export const ContentConatiner = styled.div<{ isProfile: boolean }>`
     text-align: center;
     margin-bottom: 48px;
 
+    /* GatsbyImage는 wrapper 폭만 제어해 내부 종횡비 로직을 보존한다(찌그러짐 방지) */
+    .gatsby-image-wrapper {
+      width: 100%;
+    }
+
     ${mediaQuery('tablet1024', `${size('auto', '100%')}margin-bottom: 40px;`)};
   }
 
@@ -122,10 +127,6 @@ export const ContentConatiner = styled.div<{ isProfile: boolean }>`
     @media (max-width: ${ScreenBreakPoints['mobile']}) {
       padding: ${({ isProfile }) => (isProfile ? '52px' : '40px')} 0px 64px;
     }
-  }
-
-  img {
-    width: 100%;
   }
 `;
 

--- a/src/components/news/NewsDetail/NewsDetail.tsx
+++ b/src/components/news/NewsDetail/NewsDetail.tsx
@@ -27,12 +27,13 @@ const NewsDetail = (props: Props) => {
   } = props;
 
   const dateYearMonthDate = convertDateStr(date).fullDate;
-  const [profile, setProfile] = useState<NewsProfile[] | []>([]);
+  const [profile, setProfile] = useState<NewsProfile[]>([]);
+  const [isProfileLoading, setIsProfileLoading] = useState(true);
 
   useEffect(() => {
-    getNewsMember(id).then(res => {
-      setProfile(res ?? []);
-    });
+    getNewsMember(id)
+      .then(res => setProfile(res ?? []))
+      .finally(() => setIsProfileLoading(false));
   }, []);
 
   const onClickOiriginal = () => {
@@ -50,7 +51,7 @@ const NewsDetail = (props: Props) => {
   const topTxt = isMediaNews ? agency : '최근 업무사례';
 
   const isNewsImageData = !isEmpty(newsImageData);
-  const isProfile = !isEmpty(profile) && profile.length > 0;
+  const isProfile = !isEmpty(profile);
   const isPrevContent = !isEmpty(prevNews);
   const isNextContent = !isEmpty(nextNews);
 
@@ -102,7 +103,9 @@ const NewsDetail = (props: Props) => {
           </ReactMarkdown>
         </S.Content>
         <article className="bottom">
-          {isProfile ? (
+          {/* 프로필 로딩이 끝나기 전엔 아무것도 노출하지 않아 '기사 원문보기'
+              버튼이 먼저 깜빡이는 현상을 막는다 */}
+          {isProfileLoading ? null : isProfile ? (
             <S.ProfileAreaWrapper>
               {profile.map((item, index) => {
                 return (


### PR DESCRIPTION
## 개요
뉴스 목록/상세 페이지 UI 이슈 3건 수정.

## 변경 사항
### 1. 상세 상단 이미지 찌그러짐
- `ContentConatiner`의 전역 `img { width: 100% }` 규칙이 `GatsbyImage` 내부 `<img>`에 폭을 강제해 gatsby-plugin-image의 종횡비 로직을 덮어쓰고 있었음.
- 전역 규칙 제거 → `.top .gatsby-image-wrapper { width: 100% }`로 **wrapper 폭만** 제어. 원본 비율 유지하며 풀폭 표시.
- 마크다운 본문 이미지(`S.Content`)·프로필 이미지(`S.ProfileArea`)는 각자 자체 사이즈 규칙이 있어 영향 없음.

### 2. '최근 업무사례' 탭 라벨 2줄 처리
- `Tab`에 `white-space: nowrap;` 추가 → 폰트/문구 길이와 무관하게 항상 한 줄.
- 별도 px 사이즈 지정 불필요(li가 flex라 패딩+내용 폭으로 자연 확장, 기존 `min-width`는 floor로 유지).

### 3. 프로필 노출 전 '기사 원문보기' 버튼 깜빡임
- `profile`이 `[]`로 시작 → 비동기 `getNewsMember` 응답 전 첫 렌더에서 fallback 버튼이 먼저 노출됨.
- `isProfileLoading` 게이트 추가: 로딩 완료 전엔 해당 영역 미렌더 → 버튼 깜빡임 제거.

### 정리
- `isProfile` 중복 조건 `!isEmpty(profile) && profile.length > 0` → `!isEmpty(profile)`.

## 검증
- `tsc --noEmit` 통과.

## 후속 검토(미적용)
3번의 더 근본적 해법은 `gatsby-node.ts`에서 `memberId`를 빌드 타임 page context로 내려 프로필/버튼 분기를 동기적으로 결정하는 것(깜빡임·레이아웃 시프트 0). 빌드 파이프라인은 민감 영역이라 본 PR에서는 미적용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)