### PR TITLE
fix(news): 이미지 찌그러짐·탭 줄바꿈·프로필 버튼 깜빡임 수정

### DIFF
--- a/src/components/news/Main/Main.style.ts
+++ b/src/components/news/Main/Main.style.ts
@@ -48,6 +48,7 @@ export const TabBox = styled.ul`
 export const Tab = styled.li<{ isActive?: boolean }>`
   ${flex()}
 
+  white-space: nowrap;
   letter-spacing: -0.4px;
 
   font-weight: ${FontWeight.bold};

--- a/src/components/news/NewsDetail/NewsDetail.style.ts
+++ b/src/components/news/NewsDetail/NewsDetail.style.ts
@@ -114,6 +114,13 @@ export const ContentConatiner = styled.div<{ isProfile: boolean }>`
     text-align: center;
     margin-bottom: 48px;
 
+    /* next/image는 width/height 속성으로 비율이 잡히므로, CSS로 width를 줄 땐
+       height: auto를 함께 줘 종횡비를 유지한다(찌그러짐 방지) */
+    img {
+      width: 100%;
+      height: auto;
+    }
+
     ${mediaQuery('tablet1024', `${size('auto', '100%')}margin-bottom: 40px;`)};
   }
 
@@ -122,10 +129,6 @@ export const ContentConatiner = styled.div<{ isProfile: boolean }>`
     @media (max-width: ${ScreenBreakPoints['mobile']}) {
       padding: ${({ isProfile }) => (isProfile ? '52px' : '40px')} 0px 64px;
     }
-  }
-
-  img {
-    width: 100%;
   }
 `;
 

--- a/src/components/news/NewsDetail/NewsDetail.tsx
+++ b/src/components/news/NewsDetail/NewsDetail.tsx
@@ -28,12 +28,13 @@ const NewsDetail = (props: Props) => {
 
   const router = useRouter();
   const dateYearMonthDate = convertDateStr(date).fullDate;
-  const [profile, setProfile] = useState<NewsProfile[] | []>([]);
+  const [profile, setProfile] = useState<NewsProfile[]>([]);
+  const [isProfileLoading, setIsProfileLoading] = useState(true);
 
   useEffect(() => {
-    getNewsMember(id).then(res => {
-      setProfile(res ?? []);
-    });
+    getNewsMember(id)
+      .then(res => setProfile(res ?? []))
+      .finally(() => setIsProfileLoading(false));
   }, []);
 
   const onClickOiriginal = () => {
@@ -55,7 +56,7 @@ const NewsDetail = (props: Props) => {
   const topTxt = isMediaNews ? agency : '최근 업무사례';
 
   const isNewsImageData = !isEmpty(newsImageData);
-  const isProfile = !isEmpty(profile) && profile.length > 0;
+  const isProfile = !isEmpty(profile);
   const isPrevContent = !isEmpty(prevNews);
   const isNextContent = !isEmpty(nextNews);
 
@@ -112,7 +113,9 @@ const NewsDetail = (props: Props) => {
           </ReactMarkdown>
         </S.Content>
         <article className="bottom">
-          {isProfile ? (
+          {/* 프로필 로딩이 끝나기 전엔 아무것도 노출하지 않아 '기사 원문보기'
+              버튼이 먼저 깜빡이는 현상을 막는다 */}
+          {isProfileLoading ? null : isProfile ? (
             <S.ProfileAreaWrapper>
               {profile.map((item, index) => {
                 return (


### PR DESCRIPTION
## 개요
뉴스 목록/상세 UI 이슈 3건 수정. **현재 Next.js `develop` 기준으로 작성** (PR #4는 stale Gatsby 기반이라 닫고 본 PR로 대체).

## 변경 사항
### 1. 상세 상단 이미지 찌그러짐
- `AppImage`(=next/image)는 `width`/`height` 속성으로 종횡비를 잡는데, `ContentConatiner`의 전역 `img { width: 100% }`가 `height: auto` 없이 width만 덮어써 비율이 깨짐(찌그러짐).
- 전역 규칙 제거 → `.top img { width: 100%; height: auto; }`로 스코프. 원본 비율 유지하며 풀폭 표시.
- 본문 마크다운 이미지(`S.Content`)·프로필 이미지(`S.ProfileArea`)는 각자 자체 규칙이 있어 영향 없음.

### 2. '최근 업무사례' 탭 라벨 2줄 처리
- `Tab`에 `white-space: nowrap;` 추가 → 폰트/문구 길이와 무관하게 항상 한 줄. (별도 px 지정 불필요)

### 3. 프로필 노출 전 '기사 원문보기' 버튼 깜빡임
- `profile`이 `[]`로 시작 → 비동기 `getNewsMember` 응답 전 첫 렌더에서 fallback 버튼이 먼저 노출됨.
- `isProfileLoading` 게이트 추가: 로딩 완료 전엔 미렌더. **프로필 클릭→멤버 이동 기능(#3)은 그대로 유지.**

### 정리
- `isProfile` 중복 조건 `!isEmpty(profile) && profile.length > 0` → `!isEmpty(profile)`.

## 검증
- `pnpm typecheck` 0 errors (clean).
- `pnpm exec eslint` 변경 파일 신규 경고 0건 (오히려 1건 감소).

🤖 Generated with [Claude Code](https://claude.com/claude-code)